### PR TITLE
feat(nx-cloud): setup nx workspace

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -7,7 +7,7 @@
       "options": {
         "cacheableOperations": ["build", "lint", "test", "e2e"],
         "parallel": 1,
-        "accessToken": "YzI5ZjNmNWEtZDg0MS00ODZmLWI4Y2MtZTY2OWE3OTVmNTQ4fHJlYWQtd3JpdGU=",
+        "accessToken": "ZTU0YjhkZWEtN2VmNC00OWY5LTk2YTItYmM4MmNhZjM0OTEwfHJlYWQtd3JpdGU=",
         "url": "https://staging.nx.app"
       }
     }


### PR DESCRIPTION
feat(nx-cloud): setup nx cloud workspace 
    
This commit set up Nx Cloud for your Nx workspace enabling distributed caching
and GitHub integration for fast CI and improved Developer Experience.

You can access your Nx Cloud workspace by going to 
https://cloud.nx.app/orgs/670a1aee22b1a18844d39302/workspaces/670a1b1bc0c313acbf9ede79

**Note:** This commit attempts to maintain formatting of the nx.json, however you may need to correct formatting by running an nx format command and committing the changes.